### PR TITLE
Add email reply processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,28 @@ check in on friends
 
 3. **Deactivate the environment when done:**
    ```sh
-   deactivate
-   ```
+  deactivate
+  ```
+
+## Configuration
+
+Create a `.env` file with the following variables so the scripts can send and
+receive email:
+
+```bash
+GEMINI_API_KEY=your_gemini_key
+GMAIL_ADDRESS=your_gmail_address
+GMAIL_APP_PASSWORD=your_gmail_app_password
+```
+
+Make sure IMAP access is enabled on your Gmail account. The same credentials are
+used to send the daily summary email and to check for replies.
+
+## Adding Updates via Email
+
+Reply to the daily "friends summary" email with one line per friend in the form
+`Name: your update here`. When `reminders.py` runs, it will read any unread
+replies and append those updates to `friends.yaml` under today's date.
 
 ## Running as a Daily Cron Job (Ubuntu)
 

--- a/process_replies.py
+++ b/process_replies.py
@@ -1,0 +1,68 @@
+import os
+import imaplib
+import email
+import datetime
+import yaml
+from load_dotenv import load_dotenv
+
+load_dotenv()
+
+FRIENDS_FILE = os.path.join(os.path.dirname(__file__), "friends.yaml")
+
+
+def parse_updates(body: str):
+    updates = {}
+    for line in body.splitlines():
+        line = line.strip()
+        if not line or line.startswith('>') or line.lower().startswith('on ') and 'wrote:' in line:
+            break
+        if ':' in line:
+            name, update = line.split(':', 1)
+            updates[name.strip()] = update.strip()
+    return updates
+
+
+def update_friends_yaml(updates: dict):
+    if not updates or not os.path.exists(FRIENDS_FILE):
+        return
+    with open(FRIENDS_FILE, "r") as f:
+        friends = yaml.safe_load(f)
+    today = datetime.date.today().isoformat()
+    for friend in friends:
+        if friend.get("name") in updates:
+            if not isinstance(friend.get("personal_details"), dict):
+                friend["personal_details"] = {}
+            friend["personal_details"][today] = updates[friend.get("name")]
+    with open(FRIENDS_FILE, "w") as f:
+        yaml.safe_dump(friends, f)
+
+
+def check_replies():
+    imap_server = "imap.gmail.com"
+    email_user = os.environ["GMAIL_ADDRESS"]
+    email_pass = os.environ["GMAIL_APP_PASSWORD"]
+
+    with imaplib.IMAP4_SSL(imap_server) as mail:
+        mail.login(email_user, email_pass)
+        mail.select("inbox")
+        typ, data = mail.search(None, '(UNSEEN SUBJECT "Re: friends summary")')
+        for num in data[0].split():
+            typ, msg_data = mail.fetch(num, '(RFC822)')
+            msg = email.message_from_bytes(msg_data[0][1])
+            body = ""
+            if msg.is_multipart():
+                for part in msg.walk():
+                    if part.get_content_type() == "text/plain":
+                        charset = part.get_content_charset() or "utf-8"
+                        body += part.get_payload(decode=True).decode(charset, errors='ignore')
+            else:
+                charset = msg.get_content_charset() or "utf-8"
+                body = msg.get_payload(decode=True).decode(charset, errors='ignore')
+            updates = parse_updates(body)
+            update_friends_yaml(updates)
+            mail.store(num, '+FLAGS', '\\Seen')
+        mail.logout()
+
+
+if __name__ == "__main__":
+    check_replies()

--- a/reminders.py
+++ b/reminders.py
@@ -4,8 +4,10 @@ import yaml
 from send_email import send_email
 from google import genai
 from load_dotenv import load_dotenv
+from process_replies import check_replies
 
 load_dotenv()
+check_replies()
 
 FRIENDS_FILE = os.path.join(os.path.dirname(__file__), "friends.yaml")
 


### PR DESCRIPTION
## Summary
- check for unread replies via IMAP before sending the daily summary
- parse friend updates from replies and write them to `friends.yaml`
- document environment variables and reply format

## Testing
- `python3 -m py_compile process_replies.py reminders.py send_email.py load_dotenv.py`

------
https://chatgpt.com/codex/tasks/task_e_684604487174832e871785241cf63991